### PR TITLE
correción de error en inicio del servidor back

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -4,11 +4,16 @@ const bodyParser = require('body-parser');
 const morgan = require('morgan');
 const routes = require('./routes/index.js');
 const { loadProducts } = require('./libs/initialCharge/cargeDeProductos.js')
-const { getAllCategorias } = require('./controllers/product/getProductoController')
+const { loadCategoryProduct } = require("./libs/initialCharge/cargueDeCategorias")
 
 const db =  require('./db.js');
-//getAllCategorias().then(() => loadProducts())
- loadProducts()
+
+setTimeout(async() => {
+await loadCategoryProduct()}, 1000);
+
+setTimeout(async() => {
+ await loadProducts()}, 5000);
+ //loadProducts()
 
 const server = express();
 

--- a/api/src/libs/initialCharge/cargeDeProductos.js
+++ b/api/src/libs/initialCharge/cargeDeProductos.js
@@ -1,13 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 const { Product } = require('../../db');
-const { getAllCategorias } = require("../../controllers/product/getProductoController")
+//const { loadCategoryProduct } = require("./cargueDeCategorias")
 
 const loadProducts = async () => {
 
     const rutaArchivoProductos = path.resolve(path.join(__dirname, '..', 'initialRegisters'), 'productos.json');
     try {
-        await getAllCategorias()
+        //await loadCategoryProduct()
         const count = await Product.count()
         if (count > 0) return;
         const productosJSON = fs.readFileSync(rutaArchivoProductos, 'utf-8');


### PR DESCRIPTION
correción de error en inicio del servidor back, ya que cuando se iniciaba el servidor y se hacía el cargue de categorías de productos junto con el de productos, se ejecutaba más rápido el cargue de productos y daba error porque el cargue de categorías de productos no estaba hecho, entonces tocaba darle dos veces npm star al servidor para que terminara de hacer el cargue.